### PR TITLE
feat: added subsidy content metadata client fetch method

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -40,7 +40,7 @@ ROOT_URLCONF = 'edx_rest_api_client.urls'
 
 SECRET_KEY = 'insecure-secret-key'
 
-SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'root-url-for-oauth-2'
-BACKEND_SERVICE_EDX_OAUTH2_KEY = 'your-services-application-key'
-BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'your-services-application-secret'
+ENTERPRISE_BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = 'backend-service-oauth-provider-url'
+ENTERPRISE_BACKEND_SERVICE_EDX_OAUTH2_KEY = 'your-services-application-key'
+ENTERPRISE_BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'your-services-application-secret'
 ENTERPRISE_SUBSIDY_URL = 'enterprise-subsidy-service-base-url'

--- a/test_utils/utils.py
+++ b/test_utils/utils.py
@@ -1,0 +1,22 @@
+"""
+Testing utilities for the enterprise subsidy service api client
+"""
+import requests
+
+
+class MockResponse(requests.Response):
+    """
+    Mock Requests response object used for unit testing
+    """
+
+    def __init__(self, json_data, status_code, content=None, reason=None, url=None):
+        super().__init__()
+
+        self.json_data = json_data
+        self.status_code = status_code
+        self._content = content
+        self.reason = reason
+        self.url = url
+
+    def json(self):  # pylint: disable=arguments-differ
+        return self.json_data

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,10 @@
 """
 Tests for edx_enterprise_subsidy_client.py.
 """
+from unittest import mock
+
 from edx_enterprise_subsidy_client import EnterpriseSubsidyAPIClient
+from test_utils.utils import MockResponse
 
 
 def test_client_init():
@@ -10,3 +13,26 @@ def test_client_init():
     """
     subsidy_client = EnterpriseSubsidyAPIClient()
     assert subsidy_client is not None
+
+
+@mock.patch('edx_enterprise_subsidy_client.client.OAuthAPIClient', return_value=mock.MagicMock())
+def test_client_fetch_subsidy_content_data_success(
+    mock_oauth_client,
+):
+    """
+    Test the client's ability to handle api requests to fetch subsidy content metadata from the subsidy service
+    """
+    course_key = 'edX+DemoX'
+    mocked_data = {
+        'content_uuid': '484ad134-8004-43b3-ad56-b57c83e4ba24',
+        'content_key': course_key,
+        'source': 'edX',
+        'content_price': '149.00'
+    }
+    mock_oauth_client.return_value.get.return_value = MockResponse(mocked_data, 200)
+    subsidy_service_client = EnterpriseSubsidyAPIClient()
+    response = subsidy_service_client.get_subsidy_content_data(
+        enterprise_uuid='6d3ad134-8004-43b3-ad56-c57c83e4ea21',
+        content_identifier=course_key
+    )
+    assert response == mocked_data


### PR DESCRIPTION
**Description:** api client method for fetching subsidy service related content metadata.

**JIRA:** https://2u-internal.atlassian.net/browse/ENT-6910

**Testing instructions:**

1.  install the client into a service of your choice (I chose platform- `pip install -e /edx/src/edx-enterprise-subsidy-client/`)
2.  go into the django shell
3.  make sure the subsidy service and catalog service are up and running with latest changes
4.  import the enterprise subsidy client - (`from edx_enterprise_subsidy_client.client import EnterpriseSubsidyAPIClient`)
5.  call `get_subsidy_content_data` with relevant local data - (EnterpriseSubsidyAPIClient().get_subsidy_content_data("673f1b1e-a198-4e08-85d5-35cbc1d888be", "edX+DemoX")
6.  notice the output is something like `{'content_uuid': '484ad134-8004-43b3-ad56-b57c83e4ba24', 'content_key': 'edX+DemoX', 'source': 'edX', 'content_price': '149.00'}`

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.