### PR TITLE
feat: transaction endpoint accepts `lms_user_id` instead of `learner_id`

### DIFF
--- a/edx_enterprise_subsidy_client/client.py
+++ b/edx_enterprise_subsidy_client/client.py
@@ -157,7 +157,7 @@ class EnterpriseSubsidyAPIClient:
         """
         request_payload = {
             'subsidy_uuid': str(subsidy_uuid),
-            'learner_id': lms_user_id,
+            'lms_user_id': lms_user_id,
             'content_key': content_key,
             'subsidy_access_policy_uuid': str(subsidy_access_policy_uuid),
             'metadata': metadata,


### PR DESCRIPTION
ENT-6988

Related PRs:
* https://github.com/openedx/enterprise-subsidy/pull/62
* https://github.com/openedx/enterprise-access/pull/138