### PR TITLE
feat: filter for committed and pending txs by default. ENT-7178

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[0.3.2]
+*******
+* admin-list transactions will ask to be filtered for only `committed` and `pending` states by default.
+  Caller may specify other valid states (e.g. `failed` or `created`).
+
 [0.3.1]
 *******
 * fix: correctly pass ``subsidy_uuid`` to subsidy API V2 endpoint string format.

--- a/edx_enterprise_subsidy_client/__init__.py
+++ b/edx_enterprise_subsidy_client/__init__.py
@@ -2,6 +2,6 @@
 Client for interacting with the enterprise-subsidy service..
 """
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
-from .client import EnterpriseSubsidyAPIClient, get_enterprise_subsidy_api_client
+from .client import EnterpriseSubsidyAPIClient, EnterpriseSubsidyAPIClientV2, get_enterprise_subsidy_api_client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,10 @@
 """
 Tests for edx_enterprise_subsidy_client.py.
 """
+import uuid
 from unittest import mock
 
-from edx_enterprise_subsidy_client import EnterpriseSubsidyAPIClient
+from edx_enterprise_subsidy_client import EnterpriseSubsidyAPIClient, EnterpriseSubsidyAPIClientV2
 from test_utils.utils import MockResponse
 
 
@@ -36,3 +37,47 @@ def test_client_fetch_subsidy_content_data_success(
         content_identifier=course_key
     )
     assert response == mocked_data
+
+
+@mock.patch('edx_enterprise_subsidy_client.client.OAuthAPIClient', return_value=mock.MagicMock())
+def test_v2_list_subsidy_transactions(
+    mock_oauth_client,
+):
+    """
+    Test the v2 client's ability to make API requests to the admin/transactions list view.
+    Really just tests some method signatures.
+    """
+    mocked_response_data = {
+        'next': None,
+        'previous': None,
+        'count': 0,
+        'results': 0,
+    }
+    mock_oauth_client.return_value.get.return_value = MockResponse(mocked_response_data, 200)
+
+    subsidy_uuid = uuid.uuid4()
+    lms_user_id = 123
+    content_key = 'the-best-content'
+    subsidy_access_policy_uuid = uuid.uuid4()
+
+    subsidy_service_client = EnterpriseSubsidyAPIClientV2()
+
+    response = subsidy_service_client.list_subsidy_transactions(
+        subsidy_uuid=subsidy_uuid,
+        lms_user_id=lms_user_id,
+        content_key=content_key,
+        subsidy_access_policy_uuid=subsidy_access_policy_uuid,
+        transaction_states=['committed', 'pending', 'district-of-columbia'],
+    )
+
+    assert response == mocked_response_data
+    mock_oauth_client.return_value.get.assert_called_once_with(
+        f'enterprise-subsidy-service-base-url/api/v2/subsidies/{subsidy_uuid}/admin/transactions/',
+        params={
+            'state': ['committed', 'pending'],
+            'include_aggregates': True,
+            'lms_user_id': 123,
+            'content_key': 'the-best-content',
+            'subsidy_access_policy_uuid': str(subsidy_access_policy_uuid),
+        },
+    )


### PR DESCRIPTION
**Description:**
https://2u-internal.atlassian.net/browse/ENT-7178

Now, admin-list transactions will ask to be filtered for only `committed` and `pending` states by default.  Caller may specify other valid states (e.g. `failed` or `created`).

Used in conjunction with https://github.com/openedx/enterprise-subsidy/pull/96

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
