### PR TITLE
feat: pass idempotency key during transaction creation (pt. 2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[0.3.6]
+*******
+
+* feat: pass idempotency key during transaction creation (pt. 2)
+
 [0.3.5]
 *******
 * feat: pass idempotency key during transaction creation

--- a/edx_enterprise_subsidy_client/__init__.py
+++ b/edx_enterprise_subsidy_client/__init__.py
@@ -2,6 +2,6 @@
 Client for interacting with the enterprise-subsidy service..
 """
 
-__version__ = '0.3.5'
+__version__ = '0.3.6'
 
 from .client import EnterpriseSubsidyAPIClient, EnterpriseSubsidyAPIClientV2, get_enterprise_subsidy_api_client

--- a/edx_enterprise_subsidy_client/client.py
+++ b/edx_enterprise_subsidy_client/client.py
@@ -193,7 +193,15 @@ class EnterpriseSubsidyAPIClient:
         response.raise_for_status()
         return response.json()
 
-    def create_subsidy_transaction(self, subsidy_uuid, lms_user_id, content_key, subsidy_access_policy_uuid, metadata):
+    def create_subsidy_transaction(
+        self,
+        subsidy_uuid,
+        lms_user_id,
+        content_key,
+        subsidy_access_policy_uuid,
+        metadata,
+        idempotency_key=None,
+    ):
         """
         TODO: add docstring.
         """
@@ -204,6 +212,8 @@ class EnterpriseSubsidyAPIClient:
             'subsidy_access_policy_uuid': str(subsidy_access_policy_uuid),
             'metadata': metadata,
         }
+        if idempotency_key:
+            request_payload['idempotency_key'] = idempotency_key
         response = self.client.post(
             self.TRANSACTIONS_ENDPOINT,
             json=request_payload,


### PR DESCRIPTION
For some reason, pylint complains (from the caller's perspective) unless the `idempotency_key` kwarg is set on both versions of the client.

ENT-7204