### PR TITLE
build: run python upgrade script against default branch

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -12,8 +12,8 @@ on:
 jobs:
    call-upgrade-python-requirements-workflow:
     with:
-       branch: ${{ github.event.inputs.branch }}
-       # team_reviewers: ""
+       branch: ${{ github.event.inputs.branch || github.event.repository.default_branch }}
+       team_reviewers: "business-enterprise-team"
        # email_address: email@edx.org
        send_success_notification: false
     secrets:


### PR DESCRIPTION
The automated upgrade job was running against `master` and thus always failing, this _should_ make it run against `main`.

I'm not cutting a new version for this change.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
