### PR TITLE
build: don't tag this in open releases because it is a library

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -13,11 +13,3 @@ oeps:
     oep-18: true
     oep-30:
         state: true
-openedx-release:
-    # The openedx-release key is described in OEP-10:
-    #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
-    # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
-    # Note: This will only work if the repo is in the `openedx` org in github.  Repos in other orgs that have this
-    # setting will still be treated as if they don't want to be part of the Open edX releases.
-    maybe: true   # Delete this "maybe" line when you have decided about Open edX inclusion.
-    ref: main


### PR DESCRIPTION
whether or not we want the functionality in the Open edX named release, we wouldn't want this repo tagged, as it is an installed library rather than a taggable application.
