### PR TITLE
chore: Update upgrade-python-requirements to 3.12

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,6 +13,7 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch || github.event.repository.default_branch }}
+       python_version: 3.12
        team_reviewers: "2u-enterprise"
        # email_address: email@edx.org
        send_success_notification: false
@@ -21,4 +22,4 @@ jobs:
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
        edx_smtp_username: ${{ secrets.EDX_SMTP_USERNAME }}
        edx_smtp_password: ${{ secrets.EDX_SMTP_PASSWORD }}
-    uses: edx/.github/.github/workflows/upgrade-python-requirements.yml@master
+    uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master


### PR DESCRIPTION
**Description:**
Updates the workflow to update python requirements to run with the python version `3.12`.
We also update the workflow reference from `edx` to `openedx`. The edx sourced workflow by default [runs on python 3.8](https://github.com/edx/.github/blob/b40e9bba25ffe9d7c5e32d8927f5f1cfcfeb7232/.github/workflows/upgrade-python-requirements.yml#L45-L47) while the openedx sourced workflow is [more extensible](https://github.com/openedx/.github/blob/5d7768975300f76590cd57054f42574c69a780fa/.github/workflows/upgrade-python-requirements.yml#L61-L64), allowing the user to pass in the python version they wish to run the update-python-requirements job with.

This change would also align the workflow to the [enterprise-subsidy](https://github.com/openedx/enterprise-subsidy/blob/main/.github/workflows/upgrade-python-requirements.yml) repository's update-python-requirements yml. 


**Testing instructions:**
Add some testing instructions, if applicable.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
